### PR TITLE
Skip PR comments for successful runs

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -2928,6 +2928,10 @@ async function run() {
     core$1[method](formattedMessage);
     return;
   }
+
+  // If everything is up-to-date, don't comment
+  if (verifyResult.code === "MATCH") return;
+
   const comment = { ...repo, issue_number, body: formattedMessage };
   const comments = await octokit.rest.issues.listComments({
     ...repo,

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,9 @@ async function run(): Promise<void> {
     return;
   }
 
+  // If everything is up-to-date, don't comment
+  if (verifyResult.code === "MATCH") return;
+
   const comment = { ...repo, issue_number, body: formattedMessage };
   const comments = await octokit.rest.issues.listComments({
     ...repo,


### PR DESCRIPTION
The "your database schema is up-to-date" comments become quite noisy when you push to a branch regularly. Each push generates an updated comment and sends an email.

<img width="1098" alt="image" src="https://github.com/withastro/action-studio/assets/4117920/50f3c3da-1c1e-4a06-bf22-23d8100260cd">

This PR skips commenting if no changes to the database are detected.